### PR TITLE
Handle Ctrl-{ and Ctrl-} as extended keys

### DIFF
--- a/input-keys.c
+++ b/input-keys.c
@@ -539,6 +539,7 @@ static int
 input_key_mode1(struct bufferevent *bev, key_code key)
 {
 	key_code	 onlykey;
+	static const char *fall_through_chars = "{}";
 
 	log_debug("%s: key in %llx", __func__, key);
 
@@ -558,7 +559,8 @@ input_key_mode1(struct bufferevent *bev, key_code key)
 	     onlykey == '^' ||
 	     (onlykey >= '2' && onlykey <= '8') ||
 	     (onlykey >= '@' && onlykey <= '~')))
-		return (input_key_vt10x(bev, key));
+	if (strchr(fall_through_chars, onlykey) == NULL)
+		  return (input_key_vt10x(bev, key));
 
 	return (-1);
 }


### PR DESCRIPTION
Ctrl-{ and Ctrl-} don't work in tmux and they'll be sent as Ctrl-[ and Ctrl-]. This fixes it and sends Ctrl-{ and Ctrl-} as they are.

The motivation is to use these key bindings in emacs. They're bound to `paredit-backward-barf-sexp` and `paredit-forward-barf-sexp` in paredit-mode. It's annoying not to be able to use them to edit lisp code.

I can't be sure the exact implication of this change. It might break something but so far is working for me.